### PR TITLE
Allow vmin, vmax and ch units

### DIFF
--- a/config/stylelint.config.js
+++ b/config/stylelint.config.js
@@ -21,7 +21,7 @@ module.exports = {
 
 		'unit-case': 'lower',
 		'unit-no-unknown': true,
-		'unit-whitelist': ['px', '%', 'deg', 'ms', 'em', 'vh', 'vw', 'rem', 'fr'],
+		'unit-whitelist': ['px', '%', 'deg', 'ms', 'em', 'rem', 'vh', 'vw', 'vmin', 'vmax', 'fr', 'ch'],
 
 		'value-list-comma-space-after': 'always-single-line',
 		'value-list-comma-space-before': 'never',


### PR DESCRIPTION
These are not the most used units, but can be quite handy under different circumstances. I propose that they are white listed by default.