### PR TITLE
Allow duplicate properties

### DIFF
--- a/config/stylelint.config.js
+++ b/config/stylelint.config.js
@@ -30,7 +30,7 @@ module.exports = {
 
 		'property-case': 'lower',
 
-		'declaration-block-no-duplicate-properties': true,
+		'declaration-block-no-duplicate-properties': false,
 		'declaration-block-trailing-semicolon': 'always',
 		'declaration-block-single-line-max-declarations': 0,
 		'declaration-block-semicolon-space-before': 'never',

--- a/config/stylelint.config.js
+++ b/config/stylelint.config.js
@@ -30,7 +30,7 @@ module.exports = {
 
 		'property-case': 'lower',
 
-		'declaration-block-no-duplicate-properties': false,
+		'declaration-block-no-duplicate-properties': null,
 		'declaration-block-trailing-semicolon': 'always',
 		'declaration-block-single-line-max-declarations': 0,
 		'declaration-block-semicolon-space-before': 'never',

--- a/config/stylelint.config.js
+++ b/config/stylelint.config.js
@@ -30,7 +30,6 @@ module.exports = {
 
 		'property-case': 'lower',
 
-		'declaration-block-no-duplicate-properties': null,
 		'declaration-block-trailing-semicolon': 'always',
 		'declaration-block-single-line-max-declarations': 0,
 		'declaration-block-semicolon-space-before': 'never',


### PR DESCRIPTION
This may seem strange but when working with CSS Grid the need for fallbacks to browsers not supporting it works by declaring a fallback display value. That means you will need to have two declarations of display whenever CSS Grid is used. My suggestion is that this should be allowed.