### PR TITLE
Lint property sort order

### DIFF
--- a/config/stylelint.config.js
+++ b/config/stylelint.config.js
@@ -1,6 +1,9 @@
 'use strict';
 
 module.exports = {
+	plugins: [
+		'stylelint-order'
+	],
 	rules: {
 		'color-hex-case': 'lower',
 		'color-no-invalid-hex': true,
@@ -56,5 +59,11 @@ module.exports = {
 		'selector-pseudo-element-no-unknown': true,
 		'selector-type-case': 'lower',
 		'selector-max-id': 0,
+
+		'order/order': [
+			'custom-properties',
+			'declarations'
+		],
+		'order/properties-alphabetical-order': true
 	},
 };

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "strip-ansi": "4.0.0",
     "style-loader": "0.18.2",
     "stylelint": "8.1.1",
+    "stylelint-order": "^0.8.1",
     "stylelint-webpack-plugin": "0.9.0",
     "validator": "8.1.0",
     "webpack": "3.5.6",


### PR DESCRIPTION
We used to lint property sort order. Think we should continue doing that. Stylelint requires a plugin for that to work.

Added plugin to package.json. Imported it and set rule in config.