### PR TITLE
Switch out browser-syncs open browser function with react-dev-utils one

### DIFF
--- a/packages/heisenberg-scripts/config/browsersync.config.js
+++ b/packages/heisenberg-scripts/config/browsersync.config.js
@@ -37,5 +37,6 @@ module.exports = ( port, devPort ) => {
 		codeSync: false,
 		timestamps: false,
 		logLevel: 'silent',
+		open: false,
 	};
 };

--- a/packages/heisenberg-scripts/scripts/start.js
+++ b/packages/heisenberg-scripts/scripts/start.js
@@ -87,6 +87,7 @@ async function boot() {
 	const compiler = createWebpackCompiler(
 		port,
 		devPort,
+		urlsBS.localUrlForBrowser,
 		config,
 		function onReady( showInstructions ) {
 			if ( ! showInstructions ) {

--- a/packages/heisenberg-scripts/scripts/utils/create-webpack-compiler.js
+++ b/packages/heisenberg-scripts/scripts/utils/create-webpack-compiler.js
@@ -7,6 +7,7 @@ const bs = require( 'browser-sync' );
 const chalk = require( 'chalk' );
 const clearConsole = require( 'react-dev-utils/clearConsole' );
 const formatWebpackMessages = require( 'react-dev-utils/formatWebpackMessages' );
+const openBrowser = require( 'react-dev-utils/openBrowser' );
 const webpack = require( 'webpack' );
 
 /**
@@ -32,7 +33,7 @@ if ( isSmokeTest ) {
 	};
 }
 
-module.exports = function createWebpackCompiler( port, devPort, config, onReadyCallback ) {
+module.exports = function createWebpackCompiler( port, devPort, browserUrl, config, onReadyCallback ) {
 	// "Compiler" is a low-level interface to Webpack.
 	// It lets us listen to some events and provide our own custom messages.
 	let compiler;
@@ -90,7 +91,9 @@ module.exports = function createWebpackCompiler( port, devPort, config, onReadyC
 		isFirstCompile = false;
 
 		if ( ! isBrowserSyncRunning ) {
-			browserSync.init( browserSyncConfig( port, devPort ) );
+			browserSync.init( browserSyncConfig( port, devPort ), () => {
+				openBrowser( browserUrl );
+			} );
 
 			browserSync.watch( '**/*.php', event => {
 				if ( 'change' === event ) {


### PR DESCRIPTION
Browser syncs open browser don’t check if we already have a tab open with the correct url, but react-dev-utils do.