### PR TITLE
Use the dest folder defined in options when comparing folders

### DIFF
--- a/packages/heisenberg-scripts/scripts/utils/file-size-reporter.js
+++ b/packages/heisenberg-scripts/scripts/utils/file-size-reporter.js
@@ -77,10 +77,10 @@ function printFileSizesAfterBuild( webpackStats, previousSizeMap, dest ) {
 			console.log();
 
 			switch (asset.folder) {
-				case 'dist/css':
+				case `${dest}/css`:
 					console.log( chalk.cyan( '  Stylesheets:  ' ) );
 					break;
-				case 'dist/js':
+				case `${dest}/js`:
 					console.log( chalk.cyan( '  JavaScripts:  ' ) );
 					break;
 			}


### PR DESCRIPTION
If you define a custom dest dir (see #79) we need to use that.