### PR TITLE
Add reload and debounce delay watch option to browsersync

### DIFF
--- a/packages/heisenberg-scripts/scripts/utils/create-webpack-compiler.js
+++ b/packages/heisenberg-scripts/scripts/utils/create-webpack-compiler.js
@@ -95,7 +95,10 @@ module.exports = function createWebpackCompiler( port, devPort, browserUrl, conf
 				openBrowser( browserUrl );
 			} );
 
-			browserSync.watch( '**/*.php', event => {
+			browserSync.watch( '**/*.php', {
+				reloadDelay: 1000,
+				debounceDelay: 1000,
+			}, event => {
 				if ( 'change' === event ) {
 					browserSync.reload();
 				}


### PR DESCRIPTION
BrowerSync seems to not register changes in php files that isn’t on root.

After some googleling it seems that adding a reload and debounce delay is the way to go to fix it.